### PR TITLE
make Lowercase DynamicAnimatioReplacer folder load

### DIFF
--- a/src/Parsing.cpp
+++ b/src/Parsing.cpp
@@ -374,7 +374,10 @@ namespace Parsing
 		if (substringStartPos == std::string::npos) {
 			substringStartPos = a_path.find("DynamicAnimationReplacer"sv);
 			if (substringStartPos == std::string::npos) {
-				return a_path.data();
+				substringStartPos = a_path.find("dynamicanimationreplacer"sv);
+				if (substringStartPos == std::string::npos) {
+					return a_path.data();
+				}
 			}
 		}
 

--- a/src/ReplacerMods.cpp
+++ b/src/ReplacerMods.cpp
@@ -200,7 +200,7 @@ bool SubMod::ReloadConfig()
 
 	// check if this was originally a legacy mod
 	auto directoryPathStr = directoryPath.string();
-	bool bOriginallyLegacy = directoryPathStr.find("DynamicAnimationReplacer"sv) != std::string::npos;
+	bool bOriginallyLegacy = (directoryPathStr.find("DynamicAnimationReplacer"sv) != std::string::npos) || (directoryPathStr.find("dynamicanimationreplacer"sv) != std::string::npos);
 
 	auto configPath = directoryPath / "config.json"sv;
 	auto userPath = directoryPath / "user.json"sv;


### PR DESCRIPTION
DynamicAnimationReplacer allows it folder to be lowercase which means a few DAR animation mods has that folder lower cased, and due to StripReplacerPath in parsing not accounting for this, wouldn't be loaded. to fix this i simply added a extra check for lowercase following the pattern of the pervious checks.

it might be better to lowercase the a_path string and then find. so like default windows it will be case insensitive.
same with directoryPathStr in ReloadConfig in ReplacerMods. but i barley have any experience with c++, and string_view did not seem to have a easy function or the like to lower case it, so i leave that to someone else. that knows c++ and this code better.

this might seem like a small problem, since its rare for Animation mod to use a lowercase dynamicanimationreplacer folder, but since windows is by default case insensitive, so if the first animation mod you install uses lowercase all subsequent mods files will also be place in the lowercase folder. or in case of using something like mo2 with a virtual directory, if it loads a lowercase folder first same problem.