### PR TITLE
build: use alandtse clib-ng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -422,3 +422,4 @@ FodyWeavers.xsd
 # End of https://www.toptal.com/developers/gitignore/api/cmake,visualstudio
 
 /build
+CMakeUserPresets.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "extern/CommonLibSSE"]
 	path = extern/CommonLibSSE
-	url = https://github.com/ersh1/CommonLibSSE.git
+	url = https://github.com/alandtse/CommonLibVR.git
+	branch = ng

--- a/src/Havok/Havok.h
+++ b/src/Havok/Havok.h
@@ -741,5 +741,5 @@ namespace RE
 	};
 }
 
-inline RE::hkMemoryRouter& hkGetMemoryRouter() { return *(RE::hkMemoryRouter*)(uintptr_t)SKSE::WinAPI::TlsGetValue(g_dwTlsIndex); }
+inline RE::hkMemoryRouter& hkGetMemoryRouter() { return *(RE::hkMemoryRouter*)(uintptr_t)REX::W32::TlsGetValue(g_dwTlsIndex); }
 inline void* hkHeapAlloc(int numBytes) { return hkGetMemoryRouter().heap->BlockAlloc(numBytes); }

--- a/src/UI/UIManager.cpp
+++ b/src/UI/UIManager.cpp
@@ -22,9 +22,9 @@ namespace UI
 
 		const auto renderManager = RE::BSGraphics::Renderer::GetSingleton();
 
-		const auto device = renderManager->GetRuntimeData().forwarder;
-		const auto context = renderManager->GetRuntimeData().context;
-		const auto swapChain = renderManager->GetRuntimeData().renderWindows[0].swapChain;
+		const auto device = reinterpret_cast<ID3D11Device*>(renderManager->GetRuntimeData().forwarder);
+		const auto context = reinterpret_cast<ID3D11DeviceContext*>(renderManager->GetRuntimeData().context);
+		const auto swapChain = reinterpret_cast<IDXGISwapChain*>(renderManager->GetRuntimeData().renderWindows[0].swapChain);
 
 		DXGI_SWAP_CHAIN_DESC sd{};
 		swapChain->GetDesc(&sd);


### PR DESCRIPTION
Updated submodule to use alandtse clib ng instead of private ersh1 clib, fixed winapi changes with recent clib-ng